### PR TITLE
Changes to CAS library for compatibility with Pantheon

### DIFF
--- a/phpCAS/CAS/Client.php
+++ b/phpCAS/CAS/Client.php
@@ -3103,13 +3103,20 @@ class CAS_Client
             } else {
                 $server_port = $_SERVER['HTTP_X_FORWARDED_PORT'];
             }
+            
+            // Web hosting via Pantheon produces a conflict which sets isHttps=true and $server_port=80
+            // Result of that error is an SSL_ERROR_RX_RECORD_TOO_LONG error in the browser upon redirect from webhost.asu.edu
+            // Current solution below is to not append a server port if you are running in Pantheon. Otherwise, do as originally intended.
 
-            if ( ($this->_isHttps() && $server_port!=443)
-                || (!$this->_isHttps() && $server_port!=80)
-            ) {
-                $server_url .= ':';
-                $server_url .= $server_port;
+            if (!defined('PANTHEON_ENVIRONMENT')) {
+                if ( ($this->_isHttps() && $server_port!=443)
+                    || (!$this->_isHttps() && $server_port!=80)
+                ) {
+                    $server_url .= ':';
+                    $server_url .= $server_port;
+                }
             }
+
         }
         return $server_url;
     }


### PR DESCRIPTION
Changes made within phpCAS/Client.php, line 3106-3120.

- Inserted Pantheon environment variable to prevent the library from assigning a server port when isHttps returns true.